### PR TITLE
fix getRandomInt to return valid index when there is only one item

### DIFF
--- a/src/services/moviedbService.js
+++ b/src/services/moviedbService.js
@@ -10,7 +10,7 @@ const POSTER_API_BASE_URI = 'https://image.tmdb.org/t/p/w500';
 const getRandomInt = (min, max) => {
   min = Math.ceil(min);
   max = Math.floor(max);
-  return Math.floor(Math.random() * (max - min)) + min;
+  return Math.floor(Math.random() * (max - min));
 }
 
 const getRandomMovie = (movies) => {


### PR DESCRIPTION
Fix index return from getRandomInt when there is only one item in array of Movies from getRandomMovie. If there was only one item, the return was 1 instead of 0.